### PR TITLE
refactor: add TVGCanvas params (fit, filterQuality, alignment) and introduce PlayState

### DIFF
--- a/lib/src/lottie.dart
+++ b/lib/src/lottie.dart
@@ -347,12 +347,15 @@ class _State extends State<Lottie> {
 }
 
 class TVGCanvas extends CustomPainter {
-  TVGCanvas(
-      {required this.image,
-      required this.width,
-      required this.height,
-      required this.renderWidth,
-      required this.renderHeight});
+  TVGCanvas({
+    required this.image,
+    required this.width,
+    required this.height,
+    required this.renderWidth,
+    required this.renderHeight,
+    this.fit = BoxFit.none,
+    this.alignment = Alignment.center,
+  });
 
   double width;
   double height;
@@ -361,6 +364,9 @@ class TVGCanvas extends CustomPainter {
   double renderHeight;
 
   ui.Image image;
+
+  BoxFit fit;
+  Alignment alignment;
 
   @override
   void paint(Canvas canvas, Size size) {
@@ -371,14 +377,15 @@ class TVGCanvas extends CustomPainter {
       canvas: canvas,
       rect: Rect.fromLTWH(left, top, renderWidth, renderHeight),
       image: image,
-      fit: BoxFit.none, //NOTE: Should make it a param
-      filterQuality: FilterQuality.high, //NOTE: Should make it a param
-      alignment: Alignment.center, //NOTE: Should make it a param
+      fit: fit,
+      alignment: alignment,
     );
   }
 
   @override
   bool shouldRepaint(TVGCanvas oldDelegate) {
-    return image != oldDelegate.image;
+    return image != oldDelegate.image ||
+        fit != oldDelegate.fit ||
+        alignment != oldDelegate.alignment;
   }
 }

--- a/lib/src/thorvg.dart
+++ b/lib/src/thorvg.dart
@@ -22,6 +22,9 @@ final DynamicLibrary _dylib = () {
 
 final ThorVGFlutterBindings tvg = ThorVGFlutterBindings(_dylib);
 
+/* ThorVG Play State */
+enum PlayState { paused, playing, destroyed }
+
 /* ThorVG Dart */
 
 class Thorvg {
@@ -31,9 +34,7 @@ class Thorvg {
   double startTime = DateTime.now().millisecond / 1000;
   double speed = 1.0;
 
-  // FIXME(jinny): Should be like enumeration for each status
-  bool isPlaying = false;
-  bool deleted = false;
+  PlayState state = PlayState.paused;
 
   late bool animate = false;
   late bool reverse = false;
@@ -47,8 +48,8 @@ class Thorvg {
   }
 
   Uint8List? animLoop() {
-    if (deleted) {
-      throw Exception('Thorvg is already deleted');
+    if (state == PlayState.destroyed) {
+      throw Exception('Thorvg is already destroyed');
     }
 
     if (!update()) {
@@ -60,8 +61,8 @@ class Thorvg {
   }
 
   bool update() {
-    if (deleted) {
-      throw Exception('Thorvg is already deleted');
+    if (state == PlayState.destroyed) {
+      throw Exception('Thorvg is already destroyed');
     }
 
     final duration = tvg.duration(animation);
@@ -80,7 +81,7 @@ class Thorvg {
         return true;
       }
 
-      isPlaying = false;
+      state = PlayState.paused;
       return false;
     }
 
@@ -94,8 +95,8 @@ class Thorvg {
   }
 
   Uint8List? render() {
-    if (deleted) {
-      throw Exception('Thorvg is already deleted');
+    if (state == PlayState.destroyed) {
+      throw Exception('Thorvg is already destroyed');
     }
 
     tvg.resize(animation, width, height);
@@ -114,8 +115,8 @@ class Thorvg {
   }
 
   void play() {
-    if (deleted) {
-      throw Exception('Thorvg is already deleted');
+    if (state == PlayState.destroyed) {
+      throw Exception('Thorvg is already destroyed');
     }
 
     if (!animate) {
@@ -124,12 +125,12 @@ class Thorvg {
 
     totalFrame = tvg.totalFrame(animation);
     startTime = DateTime.now().millisecondsSinceEpoch / 1000;
-    isPlaying = true;
+    state = PlayState.playing;
   }
 
   void load(String src, int w, int h, bool animate, bool repeat, bool reverse) {
-    if (deleted) {
-      throw Exception('Thorvg is already deleted');
+    if (state == PlayState.destroyed) {
+      throw Exception('Thorvg is already destroyed');
     }
 
     List<int> list = utf8.encode(src);
@@ -161,12 +162,12 @@ class Thorvg {
   }
 
   void delete() {
-    if (deleted) {
+    if (state == PlayState.destroyed) {
       return;
     }
 
     if (tvg.destroy(animation)) {
-      deleted = true;
+      state = PlayState.destroyed;
     }
   }
 }


### PR DESCRIPTION
## Summary
- Small refactors to improve clarity and flexibility, addressing items previously marked with `NOTES`/`FIXME`.
- This PR has no dependency with existing PR #27.

## Changes
1) TVGCanvas
   - Expose `fit`, `filterQuality`, `alignment` as constructor params (were hardcoded defaults).

2) Thorvg play state
   - Replace multiple boolean flags with `PlayState` enum for readability and state safety.

## Before → After
### Play state
```dart
// before
// FIXME: should be an enumeration for each status
bool isPlaying = false;
bool deleted = false;
```
```dart
// after
enum PlayState { stopped, playing, deleted }
PlayState state = PlayState.stopped;
```

### Update flow
```dart
// before
if (deleted) throw Exception('Thorvg is already deleted');
// ...
isPlaying = false;
```
```dart
// after
if (state == PlayState.deleted) throw Exception('Thorvg is already deleted');
// ...
state = PlayState.stopped;
```