### PR TITLE
Follow constraints to ensure size for Lottie

### DIFF
--- a/lib/src/lottie.dart
+++ b/lib/src/lottie.dart
@@ -333,13 +333,12 @@ class _State extends State<Lottie> {
         scale: 1.0 / dpr,
         child: CustomPaint(
           painter: TVGCanvas(
-              width: width,
-              height: height,
-              lottieWidth: lottieWidth.toDouble(),
-              lottieHeight: lottieHeight.toDouble(),
-              renderWidth: renderWidth,
-              renderHeight: renderHeight,
-              image: img!),
+            width: width,
+            height: height,
+            renderWidth: renderWidth,
+            renderHeight: renderHeight,
+            image: img!,
+          ),
         ),
       ),
     );
@@ -351,16 +350,11 @@ class TVGCanvas extends CustomPainter {
       {required this.image,
       required this.width,
       required this.height,
-      required this.lottieWidth,
-      required this.lottieHeight,
       required this.renderWidth,
       required this.renderHeight});
 
   double width;
   double height;
-
-  double lottieWidth;
-  double lottieHeight;
 
   double renderWidth;
   double renderHeight;

--- a/lib/src/lottie.dart
+++ b/lib/src/lottie.dart
@@ -146,6 +146,8 @@ class _State extends State<Lottie> {
   double get renderHeight =>
       (lottieHeight > height ? height : lottieHeight).toDouble() * dpr;
 
+  bool _constraintChecked = false;
+
   @override
   void initState() {
     super.initState();
@@ -197,18 +199,23 @@ class _State extends State<Lottie> {
   }
 
   void _updateCanvasSize() {
-    if (widget.width == 0 || widget.height == 0) {
+    if (widget.width != 0 && widget.height != 0) {
       setState(() {
-        width = lottieWidth.toDouble();
-        height = lottieHeight.toDouble();
+        width = widget.width;
+        height = widget.height;
       });
       return;
     }
 
-    setState(() {
-      width = widget.width;
-      height = widget.height;
-    });
+    if (!mounted || _constraintChecked) return;
+    final RenderBox? renderBox = context.findRenderObject() as RenderBox?;
+    if (renderBox != null) {
+      setState(() {
+        _constraintChecked = true;
+        width = widget.width == 0 ? renderBox.size.width : widget.width;
+        height = widget.height == 0 ? renderBox.size.height : widget.height;
+      });
+    }
   }
 
   /* TVG function wrapper
@@ -300,8 +307,8 @@ class _State extends State<Lottie> {
   Widget build(BuildContext context) {
     if (errorMsg.isNotEmpty) {
       return SizedBox(
-        width: widget.width.toDouble(),
-        height: widget.height.toDouble(),
+        width: widget.width,
+        height: widget.height,
         child: ErrorWidget(errorMsg),
       );
     }
@@ -318,20 +325,20 @@ class _State extends State<Lottie> {
     }
 
     return Container(
-      width: width.toDouble(),
-      height: height.toDouble(),
+      width: width,
+      height: height,
       clipBehavior: Clip.hardEdge,
       decoration: const BoxDecoration(color: Colors.transparent),
       child: Transform.scale(
         scale: 1.0 / dpr,
         child: CustomPaint(
           painter: TVGCanvas(
-              width: width.toDouble(),
-              height: height.toDouble(),
+              width: width,
+              height: height,
               lottieWidth: lottieWidth.toDouble(),
               lottieHeight: lottieHeight.toDouble(),
-              renderWidth: renderWidth.toDouble(),
-              renderHeight: renderHeight.toDouble(),
+              renderWidth: renderWidth,
+              renderHeight: renderHeight,
               image: img!),
         ),
       ),


### PR DESCRIPTION
## Related Issue

- #29 

## Approach

There are several ways to retrieve a widget’s parent constraints.
After testing different approaches, I chose the simplest one: using `context.findRenderObject()`.
This API provides the current widget’s size and constraints once the widget has been mounted.

To ensure accurate sizing, I call `context.findRenderObject()` after the first frame is painted.
Since `_updateCanvasSize()` was already being invoked at the same timing (via `PostFrameCallback`), I integrated the `findRenderObject()` logic directly into `_updateCanvasSize()`.

## Changes

- Removed the fallback that set `lottieSize` when `widget.width` and `widget.height` were not provided.
- Updated `_updateCanvasSize()` to respect parent constraints using `context.findRenderObject()`.
- Added a `_constraintChecked` flag to prevent duplicate `setState() calls`.

## Fixes

- Removed the unused `lottieSize` parameter in `TVGCanvas`.
- Removed unnecessary `toDouble()` casts on double variables.

## Tests

- Verified behavior with the following parent widgets (without explicitly setting the Lottie size):
  - `Container`
  - `ConstrainedBox`
  - `AspectRatio`
  - `Flexible`
  - `Expanded`

- No more null-size issues were observed.

It works well in my testing, but additional cross-checks would be valuable.